### PR TITLE
Upgrade to flutter 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## 0.0.1
+## [0.0.2] Feb 9, 2022
+- Support Flutter 2.10.0
+  Now its default Android Target is Android 12 (sdk 31).
+  
+## [0.0.1] Jan 13, 2022
 
-* Initial release providing the capabilities to only access the clipboard
+- Initial release providing the capabilities to only access the clipboard
 if the data matches a specific pattern. This can be used to avoid clipboard 
 access notifications on iOS 14+ and Android 12+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Safe Clipboard
+# Safe Clipboard ![Flutter 2.10.0](https://img.shields.io/badge/Flutter-2.10.0-blue)
 
 For most common use cases you can use the [Clipboard class](https://api.flutter.dev/flutter/services/Clipboard-class.html) built into Flutter.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.homex.safe_clipboard'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -88,6 +88,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -155,7 +162,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: safe_clipboard
 description: Provides access to the clipboard with additonal native options
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/HomeXLabs/safe_clipboard
 
 environment:


### PR DESCRIPTION
## Description
Upgrade Flutter 2.10.0 - Now its default Android Target is Android 12 (sdk 31).

https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects#full-flutter-app-migration